### PR TITLE
Fix failures from HTML proofer tests

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -45,8 +45,8 @@ disqus:
 
 # if you don't have any of social below, comment the line
 linkedin: matthewydong
-github: matthew-y-dong
-email: mdong@berkeley.edu
+github: matthew-dong-dev
+email: mdong.data@gmail.com
 # facebook: myfacebook
 # twitter: mytwitter
 # google: mygoogle

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -7,7 +7,7 @@
 {% if showHeader == true %}
     <header class="header-home {% if site.animation %}animated{% endif %}">
         <a class="link" href="{{ site.url }}/about">
-            <img class="selfie" src="{% if site.external-image %}{{ site.picture }}{% else %}{{ site.url }}/{{ site.picture }}{% endif %}" />
+            <img class="selfie" src="{% if site.external-image %}{{ site.picture }}{% else %}{{ site.url }}/{{ site.picture }}{% endif %}" alt="site picture"/>
         </a>
         <!-- {% if site.about %}
             <a class="link" href="{{ site.url }}/about">

--- a/about.md
+++ b/about.md
@@ -54,7 +54,7 @@ Shows
 - _Tom and Jerry_
 
 
-<img class="bigger-image" src="{{ site.url }}/assets/images/calvin-and-hobbes.png" />
+<img class="bigger-image" src="{{ site.url }}/assets/images/calvin-and-hobbes.png" alt="Calvin and Hobbes"/>
 
 
 <!-- <p class="extra">

--- a/projects.md
+++ b/projects.md
@@ -5,7 +5,7 @@ layout: page
 
 <!-- <center> <h2> Projects </h2> </center> -->
 
-<!-- <center>You can find my resume <a href="{{ site.url }}/{{ site.resume-url }}" target="_blank">here</a> and my Github profile <a href="https://github.com/matthew-y-dong" target="_blank">here</a>.</center> -->
+<!-- <center>You can find my resume <a href="{{ site.url }}/{{ site.resume-url }}" target="_blank">here</a> and my Github profile <a href="https://github.com/matthew-dong-dev" target="_blank">here</a>.</center> -->
 
 <br>
 	
@@ -18,11 +18,11 @@ Projects
 
 **CA County Waste Management**
 
-- Forecasting project predicting CA county waste generation based on historic data and other engineered features.  Scraped data from government websites, trained and evaluated different prediction models, created a geospatial heat map with optimal model projections. <a href="https://matthewydong.com/ca-waste" target="_blank">GIS Map</a>, <a href="https://github.com/matthew-y-dong/ca-waste" target="_blank">Code</a>
+- Forecasting project predicting CA county waste generation based on historic data and other engineered features.  Scraped data from government websites, trained and evaluated different prediction models, created a geospatial heat map with optimal model projections. <a href="https://matthew-dong-dev.github.io/ca-waste/" target="_blank">GIS Map</a>, <a href="https://github.com/matthew-dong-dev/ca-waste" target="_blank">Code</a>
 
 **E-waste Education Site**
 
-- Static React website describing national and regional electronic waste usage and policies with statistical visualizations. <a href="https://e-waste-info.web.app/" target="_blank">Site</a>, <a href="https://github.com/matthew-y-dong/e-waste-site" target="_blank">Code</a>
+- Static React website describing national and regional electronic waste usage and policies with statistical visualizations. <a href="https://e-waste-info.web.app/" target="_blank">Site</a>, <a href="https://github.com/matthew-dong-dev/e-waste-site" target="_blank">Code</a>
 
 <br>
 
@@ -31,6 +31,6 @@ Publications
 
 **Conference Proceedings**
 
--  <u>Dong, M</u>., Yu, R., Pardos, Z.A. (2019) Design and Deployment of a Better Course Search Tool: Inferring latent keywords from enrollment networks. In M. Scheffel & J. Broisin (Eds.) Proceedings of the 14th European Conference on Technology Enhanced Learning (ECTEL). Delft, The Netherlands. Springer. Pages 480-494.  <a href="https://link.springer.com/chapter/10.1007%2F978-3-030-29736-7_36" target="_blank">Full paper</a>, <a href="{{site.url}}/assets/files/ECTEL-paper.pdf" target="_blank">Full paper PDF</a>, <a href="https://github.com/matthew-y-dong/ICS-research" target="_blank">Code</a>
+-  <u>Dong, M</u>., Yu, R., Pardos, Z.A. (2019) Design and Deployment of a Better Course Search Tool: Inferring latent keywords from enrollment networks. In M. Scheffel & J. Broisin (Eds.) Proceedings of the 14th European Conference on Technology Enhanced Learning (ECTEL). Delft, The Netherlands. Springer. Pages 480-494.  <a href="https://link.springer.com/chapter/10.1007%2F978-3-030-29736-7_36" target="_blank">Full paper</a>, <a href="{{site.url}}/assets/files/ECTEL-paper.pdf" target="_blank">Full paper PDF</a>, <a href="https://github.com/matthew-dong-dev/ICS-research" target="_blank">Code</a>
 
 <!-- - <u>Dong, M</u>., Yu, R., Pardos, Z.A. Design and Deployment of a Better University Course Search: Inferring Latent Keywords from Enrollments. In C. Lync and A. Merceron (Eds.) Proceedings of the 12th International Conference on Educational Data Mining (EDM). Montreal, Canada.  [Short paper PDF]({{site.url}}/assets/files/EDM-paper.pdf)-->

--- a/recruiter.md
+++ b/recruiter.md
@@ -8,9 +8,9 @@ layout: page
 
 <center> <h2> Recruiter Info </h2> </center>
 
-<center>You can find my Github profile <a href="https://github.com/matthew-y-dong" target="_blank">here</a>.</center>
+<center>You can find my Github profile <a href="https://github.com/matthew-dong-dev" target="_blank">here</a>.</center>
 
-<!-- <center>You can find my resume <a href="{{ site.url }}/{{ site.resume-url }}" target="_blank">here</a> and my Github profile <a href="https://github.com/matthew-y-dong" target="_blank">here</a>.</center> -->
+<!-- <center>You can find my resume <a href="{{ site.url }}/{{ site.resume-url }}" target="_blank">here</a> and my Github profile <a href="https://github.com/matthew-dong-dev" target="_blank">here</a>.</center> -->
 
 <br>
 
@@ -29,7 +29,7 @@ Experience
 **Software Engineering Intern (Full-stack) - EcoDataLab**
 
 - Led student developer team working on carbon footprint tool <a href="https://coolclimate.org/calculator" target="_blank">(coolclimate.org/calculator)</a> used by both general public and businesses.   Worked as partial scrum master, organized sprints and communicated goals and progress with stakeholders.
-- Improved service logic to increase API response accuracy <a href="https://api-central.berkeley.edu/api/11" target="_blank">(api-central.berkeley.edu/api/11)</a>, helped containerize back-end with Docker to automate  research database refresh process, implemented UI features with React/Redux.
+- Improved service logic to increase API response accuracy <a href="https://coolclimate.org/api" target="_blank">(api-central.berkeley.edu/api/11)</a>, helped containerize back-end with Docker to automate  research database refresh process, implemented UI features with React/Redux.
 - Managed deployments through GCP Web Hosting and in-house server. 
 - Berkeley, CA (Aug 2020 - July 2021)
 
@@ -74,11 +74,11 @@ Projects
 
 **CA County Waste Management**
 
-- Forecasting project predicting CA county waste generation based on historic data and other engineered features.  Scraped data from government websites, trained and evaluated different prediction models, created a geospatial heat map with optimal model projections. <a href="https://matthewydong.com/ca-waste" target="_blank">GIS Map</a>, <a href="https://github.com/matthew-y-dong/ca-waste" target="_blank">Code</a>
+- Forecasting project predicting CA county waste generation based on historic data and other engineered features.  Scraped data from government websites, trained and evaluated different prediction models, created a geospatial heat map with optimal model projections. <a href="https://matthew-dong-dev.github.io/ca-waste/" target="_blank">GIS Map</a>, <a href="https://github.com/matthew-dong-dev/ca-waste" target="_blank">Code</a>
 
 **E-waste Education Site**
 
-- Static React website describing national and regional electronic waste usage and policies with statistical visualizations. <a href="https://e-waste-info.web.app/" target="_blank">Site</a>, <a href="https://github.com/matthew-y-dong/e-waste-site" target="_blank">Code</a>
+- Static React website describing national and regional electronic waste usage and policies with statistical visualizations. <a href="https://e-waste-info.web.app/" target="_blank">Site</a>, <a href="https://github.com/matthew-dong-dev/e-waste-site" target="_blank">Code</a>
 
 <br>
 
@@ -87,7 +87,7 @@ Awards and Publications
 
 **Conference Proceedings**
 
--  <u>Dong, M</u>., Yu, R., Pardos, Z.A. (2019) Design and Deployment of a Better Course Search Tool: Inferring latent keywords from enrollment networks. In M. Scheffel & J. Broisin (Eds.) Proceedings of the 14th European Conference on Technology Enhanced Learning (ECTEL). Delft, The Netherlands. Springer. Pages 480-494.  <a href="https://link.springer.com/chapter/10.1007%2F978-3-030-29736-7_36" target="_blank">Full paper</a>, <a href="{{site.url}}/assets/files/ECTEL-paper.pdf" target="_blank">Full paper PDF</a>, <a href="https://github.com/matthew-y-dong/ICS-research" target="_blank">Code</a>
+-  <u>Dong, M</u>., Yu, R., Pardos, Z.A. (2019) Design and Deployment of a Better Course Search Tool: Inferring latent keywords from enrollment networks. In M. Scheffel & J. Broisin (Eds.) Proceedings of the 14th European Conference on Technology Enhanced Learning (ECTEL). Delft, The Netherlands. Springer. Pages 480-494.  <a href="https://link.springer.com/chapter/10.1007%2F978-3-030-29736-7_36" target="_blank">Full paper</a>, <a href="{{site.url}}/assets/files/ECTEL-paper.pdf" target="_blank">Full paper PDF</a>, <a href="https://github.com/matthew-dong-dev/ICS-research" target="_blank">Code</a>
 
 <!-- - <u>Dong, M</u>., Yu, R., Pardos, Z.A. Design and Deployment of a Better University Course Search: Inferring Latent Keywords from Enrollments. In C. Lync and A. Merceron (Eds.) Proceedings of the 12th International Conference on Educational Data Mining (EDM). Montreal, Canada.  [Short paper PDF]({{site.url}}/assets/files/EDM-paper.pdf)-->
 


### PR DESCRIPTION
### What are the changes and why are they needed? 

- Add some form of test coverage to repository

### How has this been tested? 

html proofer no longer returns with failures

```
mdong@lenovo-ideapad:~/personal-website$ bundle exec jekyll build
mdong@lenovo-ideapad:~/personal-website$ bundle exec htmlproofer ./_site
Running 3 checks (Images, Links, Scripts) in ["./_site"] on *.html files ...


Checking 26 external links
Checking 1 internal link
Checking internal link hashes in 0 files
Ran on 8 files!


HTML-Proofer finished successfully.
Finished in 1.52 seconds
```

<!-- ### Additional notes -->